### PR TITLE
Fix a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,7 +590,7 @@ irb> alphabet | ['c']
  => ["a", "b", "c"]
 ```
 
-We can also assign more then one element at the same time:
+We can also assign more than one element at the same time:
 
 ```bash
 irb> alphabet = ['a','b','c']

--- a/snippets/adding_uniq_values_to_an_array.md
+++ b/snippets/adding_uniq_values_to_an_array.md
@@ -28,7 +28,7 @@ irb> alphabet | ['c']
  => ["a", "b", "c"]
 ```
 
-We can also assign more then one element at the same time:
+We can also assign more than one element at the same time:
 
 ```bash
 irb> alphabet = ['a','b','c']


### PR DESCRIPTION
One of the examples contains a typo, I merely fixed it.